### PR TITLE
Add role listing and creation

### DIFF
--- a/Solofront/src/app/Administracion/roles/roles.component.html
+++ b/Solofront/src/app/Administracion/roles/roles.component.html
@@ -1,1 +1,38 @@
-<p>roles works!</p>
+<div class="container mt-3">
+  <h2>Roles</h2>
+
+  <form (ngSubmit)="agregarRol()" #rolForm="ngForm" class="mb-3">
+    <div class="input-group">
+      <input
+        type="text"
+        class="form-control"
+        name="nombre"
+        [(ngModel)]="nuevoRol.nombre"
+        placeholder="Nombre del rol"
+        required
+      />
+      <button class="btn btn-primary" type="submit" [disabled]="rolForm.invalid">
+        Agregar
+      </button>
+    </div>
+  </form>
+
+  <table class="table table-striped" *ngIf="roles.length > 0">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let rol of roles">
+        <td>{{ rol.id }}</td>
+        <td>{{ rol.nombre }}</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div *ngIf="roles.length === 0">
+    No hay roles registrados.
+  </div>
+</div>

--- a/Solofront/src/app/Administracion/roles/roles.component.ts
+++ b/Solofront/src/app/Administracion/roles/roles.component.ts
@@ -1,11 +1,39 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RolService } from '../../Services/rol.service';
+import { IRol } from '../../interfases/irol';
 
 @Component({
   selector: 'app-roles',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, FormsModule],
   templateUrl: './roles.component.html',
-  styleUrl: './roles.component.css'
+  styleUrl: './roles.component.css',
 })
 export class RolesComponent {
+  roles: IRol[] = [];
+  nuevoRol: IRol = { nombre: '' };
 
+  constructor(private rolService: RolService) {}
+
+  ngOnInit() {
+    this.cargarRoles();
+  }
+
+  cargarRoles() {
+    this.rolService.getRoles().subscribe((roles) => (this.roles = roles));
+  }
+
+  agregarRol() {
+    if (!this.nuevoRol.nombre.trim()) {
+      return;
+    }
+    this.rolService
+      .addRole({ nombre: this.nuevoRol.nombre })
+      .subscribe(() => {
+        this.nuevoRol.nombre = '';
+        this.cargarRoles();
+      });
+  }
 }

--- a/Solofront/src/app/Services/rol.service.ts
+++ b/Solofront/src/app/Services/rol.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { IRol } from '../interfases/irol';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class RolService {
+  private roles: IRol[] = [];
+
+  getRoles(): Observable<IRol[]> {
+    return of(this.roles);
+  }
+
+  addRole(rol: IRol): Observable<IRol> {
+    const id = this.roles.length > 0 ? Math.max(...this.roles.map(r => r.id ?? 0)) + 1 : 1;
+    const nuevo: IRol = { id, nombre: rol.nombre };
+    this.roles.push(nuevo);
+    return of(nuevo);
+  }
+}

--- a/Solofront/src/app/interfases/irol.ts
+++ b/Solofront/src/app/interfases/irol.ts
@@ -1,0 +1,4 @@
+export interface IRol {
+    id?: number;
+    nombre: string;
+}


### PR DESCRIPTION
## Summary
- add IRol interface and RolService for in-memory roles
- expand roles component with table view and add form

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8d74e758832fb26dbead2f33e667