### PR TITLE
Add simple Node backend server

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"no tests\" && exit 0"
+  },
+  "dependencies": {}
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,42 @@
+import { createServer } from 'http';
+import { parse } from 'url';
+
+const patients = [];
+const histories = [];
+const appointments = [];
+
+function sendJson(res, status, data) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+const server = createServer((req, res) => {
+  const { pathname } = parse(req.url, true);
+  if (req.method === 'GET' && pathname === '/api/pacientes') {
+    sendJson(res, 200, patients);
+  } else if (req.method === 'POST' && pathname === '/api/pacientes') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const paciente = JSON.parse(body);
+        paciente.id = patients.length + 1;
+        patients.push(paciente);
+        sendJson(res, 201, paciente);
+      } catch (err) {
+        sendJson(res, 400, { message: 'Invalid JSON' });
+      }
+    });
+  } else if (req.method === 'GET' && pathname === '/api/historias') {
+    sendJson(res, 200, histories);
+  } else if (req.method === 'GET' && pathname === '/api/citas') {
+    sendJson(res, 200, appointments);
+  } else {
+    sendJson(res, 404, { message: 'Not found' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Backend running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add minimal Node.js backend exposing basic patient, history, and appointment routes
- set up npm scripts and gitignore for the backend

## Testing
- `npm test` (backend)
- `npm test -- --watch=false --browsers=ChromeHeadless` (frontend) *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68c624510648832f9f87777161fa5d62