### PR TITLE
feat: add invoice report script

### DIFF
--- a/Solofront/README.md
+++ b/Solofront/README.md
@@ -57,3 +57,13 @@ Angular CLI does not come with an end-to-end testing framework by default. You c
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+
+## Invoice report script
+
+This project includes a small Node.js script that generates a sample invoice report in the console. To run it with the example data, execute:
+
+```bash
+node src/invoice-report.js
+```
+
+You can also import the `generateInvoiceReport` function from this file and provide your own invoice data to produce a formatted summary.

--- a/Solofront/README.md
+++ b/Solofront/README.md
@@ -60,10 +60,16 @@ For more information on using the Angular CLI, including detailed command refere
 
 ## Invoice report script
 
-This project includes a small Node.js script that generates a sample invoice report in the console. To run it with the example data, execute:
+This project includes a small JavaScript invoice report script that can run in Node.js or directly in the browser.
+
+### Console
+
+To print the sample data in the console:
 
 ```bash
 node src/invoice-report.js
 ```
 
-You can also import the `generateInvoiceReport` function from this file and provide your own invoice data to produce a formatted summary.
+### Browser
+
+Open `src/invoice-report.html` in any web browser to view the same invoice rendered as an HTML table. The script exposes a `renderInvoiceReport` function that you can reuse to display custom invoice data inside your own pages.

--- a/Solofront/src/invoice-report.html
+++ b/Solofront/src/invoice-report.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Reporte de Factura</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+    tfoot td { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Reporte de Factura</h1>
+  <div id="invoice-report"></div>
+  <script src="invoice-report.js"></script>
+  <script>
+    const sampleInvoice = {
+      number: 'FAC-001',
+      customer: 'Cliente de ejemplo',
+      items: [
+        { description: 'Producto A', quantity: 2, price: 10 },
+        { description: 'Producto B', quantity: 1, price: 20 }
+      ],
+      taxRate: 0.18
+    };
+    renderInvoiceReport(sampleInvoice);
+  </script>
+</body>
+</html>

--- a/Solofront/src/invoice-report.js
+++ b/Solofront/src/invoice-report.js
@@ -1,0 +1,46 @@
+/**
+ * Generates a simple invoice report in the console.
+ *
+ * @param {Object} invoice - The invoice data.
+ * @param {string} invoice.number - Invoice number.
+ * @param {string} invoice.customer - Customer name.
+ * @param {Array<{description: string, quantity: number, price: number}>} invoice.items - Items of invoice.
+ * @param {number} invoice.taxRate - Tax rate (e.g. 0.18 for 18%).
+ * @returns {{subtotal:number, tax:number, total:number}} Calculated totals.
+ */
+function generateInvoiceReport(invoice) {
+  let subtotal = 0;
+  console.log(`Factura: ${invoice.number}`);
+  console.log(`Cliente: ${invoice.customer}`);
+  console.log('Detalle:');
+  invoice.items.forEach((item) => {
+    const lineTotal = item.quantity * item.price;
+    subtotal += lineTotal;
+    console.log(` - ${item.description} (${item.quantity} x ${formatCurrency(item.price)}) = ${formatCurrency(lineTotal)}`);
+  });
+  const tax = subtotal * invoice.taxRate;
+  const total = subtotal + tax;
+  console.log(`Subtotal: ${formatCurrency(subtotal)}`);
+  console.log(`Impuesto (${invoice.taxRate * 100}%): ${formatCurrency(tax)}`);
+  console.log(`Total: ${formatCurrency(total)}`);
+  return { subtotal, tax, total };
+}
+
+function formatCurrency(amount) {
+  return new Intl.NumberFormat('es-PE', { style: 'currency', currency: 'PEN' }).format(amount);
+}
+
+if (require.main === module) {
+  const sampleInvoice = {
+    number: 'FAC-001',
+    customer: 'Cliente de ejemplo',
+    items: [
+      { description: 'Producto A', quantity: 2, price: 10 },
+      { description: 'Producto B', quantity: 1, price: 20 }
+    ],
+    taxRate: 0.18
+  };
+  generateInvoiceReport(sampleInvoice);
+}
+
+module.exports = { generateInvoiceReport };

--- a/Solofront/src/invoice-report.js
+++ b/Solofront/src/invoice-report.js
@@ -1,5 +1,5 @@
 /**
- * Generates a simple invoice report in the console.
+ * Generates a simple invoice report either in the console or the browser.
  *
  * @param {Object} invoice - The invoice data.
  * @param {string} invoice.number - Invoice number.
@@ -8,21 +8,57 @@
  * @param {number} invoice.taxRate - Tax rate (e.g. 0.18 for 18%).
  * @returns {{subtotal:number, tax:number, total:number}} Calculated totals.
  */
-function generateInvoiceReport(invoice) {
+function calculateTotals(invoice) {
   let subtotal = 0;
+  invoice.items.forEach((item) => {
+    subtotal += item.quantity * item.price;
+  });
+  const tax = subtotal * invoice.taxRate;
+  const total = subtotal + tax;
+  return { subtotal, tax, total };
+}
+
+function generateInvoiceReport(invoice) {
+  const { subtotal, tax, total } = calculateTotals(invoice);
   console.log(`Factura: ${invoice.number}`);
   console.log(`Cliente: ${invoice.customer}`);
   console.log('Detalle:');
   invoice.items.forEach((item) => {
     const lineTotal = item.quantity * item.price;
-    subtotal += lineTotal;
     console.log(` - ${item.description} (${item.quantity} x ${formatCurrency(item.price)}) = ${formatCurrency(lineTotal)}`);
   });
-  const tax = subtotal * invoice.taxRate;
-  const total = subtotal + tax;
   console.log(`Subtotal: ${formatCurrency(subtotal)}`);
   console.log(`Impuesto (${invoice.taxRate * 100}%): ${formatCurrency(tax)}`);
   console.log(`Total: ${formatCurrency(total)}`);
+  return { subtotal, tax, total };
+}
+
+function renderInvoiceReport(invoice, containerId = 'invoice-report') {
+  const { subtotal, tax, total } = calculateTotals(invoice);
+  const container = typeof containerId === 'string' ? document.getElementById(containerId) : containerId;
+  if (!container) {
+    return { subtotal, tax, total };
+  }
+  const table = document.createElement('table');
+  const rows = invoice.items
+    .map((item) => {
+      const lineTotal = item.quantity * item.price;
+      return `<tr><td>${item.description}</td><td>${item.quantity}</td><td>${formatCurrency(item.price)}</td><td>${formatCurrency(lineTotal)}</td></tr>`;
+    })
+    .join('');
+  table.innerHTML = `
+    <thead>
+      <tr><th>Descripción</th><th>Cantidad</th><th>Precio</th><th>Total</th></tr>
+    </thead>
+    <tbody>${rows}</tbody>
+    <tfoot>
+      <tr><td colspan="3">Subtotal</td><td>${formatCurrency(subtotal)}</td></tr>
+      <tr><td colspan="3">Impuesto (${invoice.taxRate * 100}%)</td><td>${formatCurrency(tax)}</td></tr>
+      <tr><td colspan="3"><strong>Total</strong></td><td><strong>${formatCurrency(total)}</strong></td></tr>
+    </tfoot>
+  `;
+  container.innerHTML = '';
+  container.appendChild(table);
   return { subtotal, tax, total };
 }
 
@@ -30,7 +66,14 @@ function formatCurrency(amount) {
   return new Intl.NumberFormat('es-PE', { style: 'currency', currency: 'PEN' }).format(amount);
 }
 
-if (require.main === module) {
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { generateInvoiceReport, renderInvoiceReport };
+} else {
+  window.generateInvoiceReport = generateInvoiceReport;
+  window.renderInvoiceReport = renderInvoiceReport;
+}
+
+if (typeof require === 'function' && require.main === module) {
   const sampleInvoice = {
     number: 'FAC-001',
     customer: 'Cliente de ejemplo',
@@ -42,5 +85,3 @@ if (require.main === module) {
   };
   generateInvoiceReport(sampleInvoice);
 }
-
-module.exports = { generateInvoiceReport };


### PR DESCRIPTION
## Summary
- add sample JavaScript invoice report generator
- document script usage in README

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68c77726241c832f80cf207c98e925f0